### PR TITLE
Fix for JSON deserialization issue

### DIFF
--- a/src/main/kotlin/com/boomerangg/springgroovy/webconsole/dto/ScriptDto.kt
+++ b/src/main/kotlin/com/boomerangg/springgroovy/webconsole/dto/ScriptDto.kt
@@ -1,5 +1,8 @@
 package com.boomerangg.springgroovy.webconsole.dto
 
+import com.fasterxml.jackson.annotation.JsonProperty
+
 data class ScriptDto(
+    @param:JsonProperty("script")
     val script: String,
 )


### PR DESCRIPTION
I do not fully understand why, but I needed this little change to make the console work in my application. Without it, I am getting
```
.w.s.m.s.DefaultHandlerExceptionResolver : Resolved [org.springframework.http.converter.HttpMessageNotReadableException: JSON parse error:
 Cannot construct instance of `com.boomerangg.springgroovy.webconsole.dto.ScriptDto` (although at least one Creator exists): cannot deserialize from Object value (no delegate- or property-
based Creator)]
```
Maybe some jackson version conflict?

Anyway, coming from a hybris background, having a groovy console again is awesome - thank you!!